### PR TITLE
fix(ui): remove inline overflow:hidden, switch h-screen to h-dvh, and apply overscroll-behavior none

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -66,13 +66,7 @@ export default function HomePage() {
   }, []);
 
   return (
-    <main className="relative h-screen">
-      <style>{`
-        html, body {
-          overflow: hidden;
-        }
-      `}</style>
-
+    <main className="relative h-dvh">
       <h1 className="sr-only">Animate UI</h1>
 
       <motion.div
@@ -125,7 +119,7 @@ export default function HomePage() {
         </div>
       </motion.div>
 
-      <div className="h-screen w-full flex items-center">
+      <div className="h-dvh w-full flex items-center">
         <motion.div
           variants={contentVariants}
           initial="hidden"

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -66,7 +66,7 @@ export default function HomePage() {
   }, []);
 
   return (
-    <main className="relative h-dvh">
+    <main className="relative h-dvh overflow-hidden">
       <h1 className="sr-only">Animate UI</h1>
 
       <motion.div

--- a/app/global.css
+++ b/app/global.css
@@ -220,8 +220,10 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
+    overscroll-behavior: none;
   }
 
   a[href^='/docs/installation'] > svg[data-icon='true'] {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -96,7 +96,7 @@ export default function Layout({ children }: { children: React.ReactNode }) {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
       </head>
-      <body className="flex flex-col min-h-screen">
+      <body className="flex flex-col min-h-dvh">
         <RootProvider theme={{ defaultTheme: 'dark' }}>
           <Providers>{children}</Providers>
         </RootProvider>


### PR DESCRIPTION
- Removing the inline `<style>{overflow: hidden}</style>` block  
- Replacing `h-screen` with `h-dvh` for better handling of dynamic viewport height (especially on mobile browsers)  
- Adding `overscroll-behavior: none` to `body` to prevent scroll chaining and bounce effects