### PR TITLE
feat: add optional thousandSeparator prop to SlidingNumber

### DIFF
--- a/apps/www/registry/text/sliding-number/index.tsx
+++ b/apps/www/registry/text/sliding-number/index.tsx
@@ -103,6 +103,7 @@ type SlidingNumberProps = React.ComponentProps<'span'> & {
   padStart?: boolean;
   decimalSeparator?: string;
   decimalPlaces?: number;
+  thousandSeparator?: string;
   transition?: SpringOptions;
 };
 
@@ -116,6 +117,7 @@ function SlidingNumber({
   padStart = false,
   decimalSeparator = '.',
   decimalPlaces = 0,
+  thousandSeparator,
   transition = {
     stiffness: 200,
     damping: 20,
@@ -204,15 +206,24 @@ function SlidingNumber({
     >
       {isInView && Number(number) < 0 && <span className="mr-1">-</span>}
 
-      {intPlaces.map((place) => (
-        <SlidingNumberRoller
-          key={`int-${place}`}
-          prevValue={parseInt(adjustedPrevInt, 10)}
-          value={parseInt(newIntStr ?? '0', 10)}
-          place={place}
-          transition={transition}
-        />
-      ))}
+      {intPlaces.map((place, idx) => {
+        const isSeparatorPosition =
+          typeof thousandSeparator !== "undefined" &&
+          (idx + 1) % 3 === 0 && // every 3 digits
+          idx !== intPlaces.length - 1; // skip before first digit
+
+        return (
+          <React.Fragment key={`int-${place}`}>
+            <SlidingNumberRoller
+              prevValue={parseInt(adjustedPrevInt, 10)}
+              value={parseInt(newIntStr ?? "0", 10)}
+              place={place}
+              transition={transition}
+            />
+            {isSeparatorPosition && <span>{thousandSeparator}</span>}
+          </React.Fragment>
+        );
+      })}
 
       {newDecStrRaw && (
         <>


### PR DESCRIPTION
# What's changed?
- Added a new optional prop `thousandSeparator?: string` to the `SlidingNumber` component.
- The prop allows inserting a custom separator (e.g. comma, dot) between every group of three digits in the integer part.
- Ensured that the separator is rendered exactly as provided.

# Why it’s useful?
- Improves number readability by supporting common formatting patterns (`1,234,567`, `1.234.567`).
- Provides flexibility for international use cases where thousand separators differ by locale.
- Backwards compatible — if thousandSeparator is not provided, the component behaves as before.

# Example usage

```
<SlidingNumber number={346924384} decimalSeparator="," decimalPlaces={3} thousandSeparator="." />
// → 346.924,384
```


https://github.com/user-attachments/assets/85e20750-7cd9-4d00-bbf7-b2fb9417de32

