### PR TITLE
fix: correct component names from TabContents to TabsContents

### DIFF
--- a/apps/www/content/docs/components/radix/tabs.mdx
+++ b/apps/www/content/docs/components/radix/tabs.mdx
@@ -20,12 +20,12 @@ author:
     <TabsTrigger value="account">Account</TabsTrigger>
     <TabsTrigger value="password">Password</TabsTrigger>
   </TabsList>
-  <TabContents>
+  <TabsContents>
     <TabsContent value="account">
       Make changes to your account here.
     </TabsContent>
     <TabsContent value="password">Change your password here.</TabsContent>
-  </TabContents>
+  </TabsContents>
 </Tabs>
 ```
 


### PR DESCRIPTION
correct component names from TabContents to TabsContents in documentation only.