### PR TITLE
feat: add insert between icons

### DIFF
--- a/apps/www/__registry__/index.tsx
+++ b/apps/www/__registry__/index.tsx
@@ -10537,6 +10537,254 @@ export const index: Record<string, any> = {
     })(),
     command: '@animate-ui/icons-bell-ring',
   },
+  'icons-between-horizontal-end': {
+    name: 'icons-between-horizontal-end',
+    description: 'Between horizontal end icon component.',
+    type: 'registry:ui',
+    dependencies: ['motion'],
+    devDependencies: undefined,
+    registryDependencies: ['@animate-ui/icons-icon'],
+    files: [
+      {
+        path: 'registry/icons/between-horizontal-end/index.tsx',
+        type: 'registry:ui',
+        target: 'components/animate-ui/icons/between-horizontal-end.tsx',
+        content:
+          "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenHorizontalEndProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    topRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    bottomRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    topRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    bottomRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenHorizontalEndProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={13}\n        height={7}\n        x={3}\n        y={3}\n        rx={1}\n        variants={variants.topRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m22 15-3-3 3-3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={13}\n        height={7}\n        x={3}\n        y={14}\n        rx={1}\n        variants={variants.bottomRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenHorizontalEnd(props: BetweenHorizontalEndProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenHorizontalEnd,\n  BetweenHorizontalEnd as BetweenHorizontalEndIcon,\n  type BetweenHorizontalEndProps,\n  type BetweenHorizontalEndProps as BetweenHorizontalEndIconProps,\n};",
+      },
+    ],
+    keywords: [
+      'insert',
+      'add',
+      'left',
+      'slot',
+      'squeeze',
+      'space',
+      'grid',
+      'table',
+      'rows',
+      'cells',
+      'excel',
+      'spreadsheet',
+      'accountancy',
+      'data',
+      'enter',
+      'entry',
+      'entries',
+      'blocks',
+      'rectangles',
+      'chevron',
+      'between',
+      'horizontal',
+      'end',
+    ],
+    component: (function () {
+      const LazyComp = React.lazy(async () => {
+        const mod = await import(
+          '@/registry/icons/between-horizontal-end/index.tsx'
+        );
+        const exportName =
+          Object.keys(mod).find(
+            (key) =>
+              typeof mod[key] === 'function' || typeof mod[key] === 'object',
+          ) || 'icons-between-horizontal-end';
+        const Comp = mod.default || mod[exportName];
+        if (mod.animations) {
+          (LazyComp as any).animations = mod.animations;
+        }
+        return { default: Comp };
+      });
+      LazyComp.demoProps = {};
+      return LazyComp;
+    })(),
+    command: '@animate-ui/icons-between-horizontal-end',
+  },
+  'icons-between-horizontal-start': {
+    name: 'icons-between-horizontal-start',
+    description: 'Between horizontal start icon component.',
+    type: 'registry:ui',
+    dependencies: ['motion'],
+    devDependencies: undefined,
+    registryDependencies: ['@animate-ui/icons-icon'],
+    files: [
+      {
+        path: 'registry/icons/between-horizontal-start/index.tsx',
+        type: 'registry:ui',
+        target: 'components/animate-ui/icons/between-horizontal-start.tsx',
+        content:
+          "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenHorizontalStartProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    topRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    bottomRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    topRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    bottomRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenHorizontalStartProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={13}\n        height={7}\n        x={8}\n        y={3}\n        rx={1}\n        variants={variants.topRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m2 9 3 3-3 3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={13}\n        height={7}\n        x={8}\n        y={14}\n        rx={1}\n        variants={variants.bottomRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenHorizontalStart(props: BetweenHorizontalStartProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenHorizontalStart,\n  BetweenHorizontalStart as BetweenHorizontalStartIcon,\n  type BetweenHorizontalStartProps,\n  type BetweenHorizontalStartProps as BetweenHorizontalStartIconProps,\n};",
+      },
+    ],
+    keywords: [
+      'insert',
+      'add',
+      'right',
+      'slot',
+      'squeeze',
+      'space',
+      'grid',
+      'table',
+      'rows',
+      'cells',
+      'excel',
+      'spreadsheet',
+      'accountancy',
+      'data',
+      'enter',
+      'entry',
+      'entries',
+      'blocks',
+      'rectangles',
+      'chevron',
+      'between',
+      'horizontal',
+      'start',
+    ],
+    component: (function () {
+      const LazyComp = React.lazy(async () => {
+        const mod = await import(
+          '@/registry/icons/between-horizontal-start/index.tsx'
+        );
+        const exportName =
+          Object.keys(mod).find(
+            (key) =>
+              typeof mod[key] === 'function' || typeof mod[key] === 'object',
+          ) || 'icons-between-horizontal-start';
+        const Comp = mod.default || mod[exportName];
+        if (mod.animations) {
+          (LazyComp as any).animations = mod.animations;
+        }
+        return { default: Comp };
+      });
+      LazyComp.demoProps = {};
+      return LazyComp;
+    })(),
+    command: '@animate-ui/icons-between-horizontal-start',
+  },
+  'icons-between-vertical-end': {
+    name: 'icons-between-vertical-end',
+    description: 'Between vertical end icon component.',
+    type: 'registry:ui',
+    dependencies: ['motion'],
+    devDependencies: undefined,
+    registryDependencies: ['@animate-ui/icons-icon'],
+    files: [
+      {
+        path: 'registry/icons/between-vertical-end/index.tsx',
+        type: 'registry:ui',
+        target: 'components/animate-ui/icons/between-vertical-end.tsx',
+        content:
+          "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenVerticalEndProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    leftRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    rightRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    leftRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    rightRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenVerticalEndProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={7}\n        height={13}\n        x={3}\n        y={3}\n        rx={1}\n        variants={variants.leftRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m9 22 3-3 3 3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={7}\n        height={13}\n        x={14}\n        y={3}\n        rx={1}\n        variants={variants.rightRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenVerticalEnd(props: BetweenVerticalEndProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenVerticalEnd,\n  BetweenVerticalEnd as BetweenVerticalEndIcon,\n  type BetweenVerticalEndProps,\n  type BetweenVerticalEndProps as BetweenVerticalEndIconProps,\n};",
+      },
+    ],
+    keywords: [
+      'insert',
+      'add',
+      'down',
+      'slot',
+      'squeeze',
+      'space',
+      'grid',
+      'table',
+      'columns',
+      'cells',
+      'excel',
+      'spreadsheet',
+      'accountancy',
+      'data',
+      'enter',
+      'entry',
+      'entries',
+      'blocks',
+      'rectangles',
+      'chevron',
+      'between',
+      'vertical',
+      'end',
+    ],
+    component: (function () {
+      const LazyComp = React.lazy(async () => {
+        const mod = await import(
+          '@/registry/icons/between-vertical-end/index.tsx'
+        );
+        const exportName =
+          Object.keys(mod).find(
+            (key) =>
+              typeof mod[key] === 'function' || typeof mod[key] === 'object',
+          ) || 'icons-between-vertical-end';
+        const Comp = mod.default || mod[exportName];
+        if (mod.animations) {
+          (LazyComp as any).animations = mod.animations;
+        }
+        return { default: Comp };
+      });
+      LazyComp.demoProps = {};
+      return LazyComp;
+    })(),
+    command: '@animate-ui/icons-between-vertical-end',
+  },
+  'icons-between-vertical-start': {
+    name: 'icons-between-vertical-start',
+    description: 'Between vertical start icon component.',
+    type: 'registry:ui',
+    dependencies: ['motion'],
+    devDependencies: undefined,
+    registryDependencies: ['@animate-ui/icons-icon'],
+    files: [
+      {
+        path: 'registry/icons/between-vertical-start/index.tsx',
+        type: 'registry:ui',
+        target: 'components/animate-ui/icons/between-vertical-start.tsx',
+        content:
+          "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenVerticalStartProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    leftRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    rightRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    leftRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    rightRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenVerticalStartProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={7}\n        height={13}\n        x={3}\n        y={8}\n        rx={1}\n        variants={variants.leftRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m15 2-3 3-3-3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={7}\n        height={13}\n        x={14}\n        y={8}\n        rx={1}\n        variants={variants.rightRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenVerticalStart(props: BetweenVerticalStartProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenVerticalStart,\n  BetweenVerticalStart as BetweenVerticalStartIcon,\n  type BetweenVerticalStartProps,\n  type BetweenVerticalStartProps as BetweenVerticalStartIconProps,\n};",
+      },
+    ],
+    keywords: [
+      'insert',
+      'add',
+      'up',
+      'slot',
+      'squeeze',
+      'space',
+      'grid',
+      'table',
+      'columns',
+      'cells',
+      'excel',
+      'spreadsheet',
+      'accountancy',
+      'data',
+      'enter',
+      'entry',
+      'entries',
+      'blocks',
+      'rectangles',
+      'chevron',
+      'between',
+      'vertical',
+      'start',
+    ],
+    component: (function () {
+      const LazyComp = React.lazy(async () => {
+        const mod = await import(
+          '@/registry/icons/between-vertical-start/index.tsx'
+        );
+        const exportName =
+          Object.keys(mod).find(
+            (key) =>
+              typeof mod[key] === 'function' || typeof mod[key] === 'object',
+          ) || 'icons-between-vertical-start';
+        const Comp = mod.default || mod[exportName];
+        if (mod.animations) {
+          (LazyComp as any).animations = mod.animations;
+        }
+        return { default: Comp };
+      });
+      LazyComp.demoProps = {};
+      return LazyComp;
+    })(),
+    command: '@animate-ui/icons-between-vertical-start',
+  },
   'icons-binary': {
     name: 'icons-binary',
     description: 'Binary icon component.',

--- a/apps/www/components/docs/icons.tsx
+++ b/apps/www/components/docs/icons.tsx
@@ -163,6 +163,15 @@ const addedIcons = [
     date: '2025-10-18',
     icons: ['icons-arrow-up-down'],
   },
+  {
+    date: '2025-10-21',
+    icons: [
+      'icons-between-horizontal-end',
+      'icons-between-horizontal-start',
+      'icons-between-vertical-end',
+      'icons-between-vertical-start',
+    ],
+  },
 ];
 
 const thirtyDaysAgo = new Date();

--- a/apps/www/content/docs/changelog.mdx
+++ b/apps/www/content/docs/changelog.mdx
@@ -17,6 +17,27 @@ import {
 <ChangelogItem date="2025-10-21">
   <ChangelogItemVersion>
 
+## 1.0.17
+
+  </ChangelogItemVersion>
+
+<ChangelogItemTitle>Icons</ChangelogItemTitle>
+
+<ChangelogItemDescription>
+
+- Added **4 new icon** by [Matthew Smith](https://github.com/Matthew-Smith):
+  - `between-horizontal-end`
+  - `between-horizontal-start`
+  - `between-vertical-end`
+  - `between-vertical-start`
+
+</ChangelogItemDescription>
+
+</ChangelogItem>
+
+<ChangelogItem date="2025-10-21">
+  <ChangelogItemVersion>
+
 ## 1.0.16
 
   </ChangelogItemVersion>

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animate-ui",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/www/public/r/icons-between-horizontal-end.json
+++ b/apps/www/public/r/icons-between-horizontal-end.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-horizontal-end",
+  "type": "registry:ui",
+  "title": "Between Horizontal End Icon",
+  "description": "Between horizontal end icon component.",
+  "dependencies": [
+    "motion"
+  ],
+  "registryDependencies": [
+    "@animate-ui/icons-icon"
+  ],
+  "files": [
+    {
+      "path": "registry/icons/between-horizontal-end/index.tsx",
+      "content": "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenHorizontalEndProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    topRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    bottomRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    topRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    bottomRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenHorizontalEndProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={13}\n        height={7}\n        x={3}\n        y={3}\n        rx={1}\n        variants={variants.topRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m22 15-3-3 3-3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={13}\n        height={7}\n        x={3}\n        y={14}\n        rx={1}\n        variants={variants.bottomRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenHorizontalEnd(props: BetweenHorizontalEndProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenHorizontalEnd,\n  BetweenHorizontalEnd as BetweenHorizontalEndIcon,\n  type BetweenHorizontalEndProps,\n  type BetweenHorizontalEndProps as BetweenHorizontalEndIconProps,\n};\n",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-horizontal-end.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "left",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "rows",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "horizontal",
+      "end"
+    ]
+  }
+}

--- a/apps/www/public/r/icons-between-horizontal-start.json
+++ b/apps/www/public/r/icons-between-horizontal-start.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-horizontal-start",
+  "type": "registry:ui",
+  "title": "Between Horizontal Start Icon",
+  "description": "Between horizontal start icon component.",
+  "dependencies": [
+    "motion"
+  ],
+  "registryDependencies": [
+    "@animate-ui/icons-icon"
+  ],
+  "files": [
+    {
+      "path": "registry/icons/between-horizontal-start/index.tsx",
+      "content": "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenHorizontalStartProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    topRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    bottomRect: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    topRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    bottomRect: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenHorizontalStartProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={13}\n        height={7}\n        x={8}\n        y={3}\n        rx={1}\n        variants={variants.topRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m2 9 3 3-3 3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={13}\n        height={7}\n        x={8}\n        y={14}\n        rx={1}\n        variants={variants.bottomRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenHorizontalStart(props: BetweenHorizontalStartProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenHorizontalStart,\n  BetweenHorizontalStart as BetweenHorizontalStartIcon,\n  type BetweenHorizontalStartProps,\n  type BetweenHorizontalStartProps as BetweenHorizontalStartIconProps,\n};\n",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-horizontal-start.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "right",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "rows",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "horizontal",
+      "start"
+    ]
+  }
+}

--- a/apps/www/public/r/icons-between-vertical-end.json
+++ b/apps/www/public/r/icons-between-vertical-end.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-vertical-end",
+  "type": "registry:ui",
+  "title": "Between Vertical End Icon",
+  "description": "Between vertical end icon component.",
+  "dependencies": [
+    "motion"
+  ],
+  "registryDependencies": [
+    "@animate-ui/icons-icon"
+  ],
+  "files": [
+    {
+      "path": "registry/icons/between-vertical-end/index.tsx",
+      "content": "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenVerticalEndProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    leftRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    rightRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: -3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    leftRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    rightRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, -3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenVerticalEndProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={7}\n        height={13}\n        x={3}\n        y={3}\n        rx={1}\n        variants={variants.leftRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m9 22 3-3 3 3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={7}\n        height={13}\n        x={14}\n        y={3}\n        rx={1}\n        variants={variants.rightRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenVerticalEnd(props: BetweenVerticalEndProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenVerticalEnd,\n  BetweenVerticalEnd as BetweenVerticalEndIcon,\n  type BetweenVerticalEndProps,\n  type BetweenVerticalEndProps as BetweenVerticalEndIconProps,\n};\n",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-vertical-end.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "down",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "columns",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "vertical",
+      "end"
+    ]
+  }
+}

--- a/apps/www/public/r/icons-between-vertical-start.json
+++ b/apps/www/public/r/icons-between-vertical-start.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-vertical-start",
+  "type": "registry:ui",
+  "title": "Between Vertical Start Icon",
+  "description": "Between vertical start icon component.",
+  "dependencies": [
+    "motion"
+  ],
+  "registryDependencies": [
+    "@animate-ui/icons-icon"
+  ],
+  "files": [
+    {
+      "path": "registry/icons/between-vertical-start/index.tsx",
+      "content": "'use client';\n\nimport * as React from 'react';\nimport { motion, type Variants } from 'motion/react';\n\nimport {\n  getVariants,\n  useAnimateIconContext,\n  IconWrapper,\n  type IconProps,\n} from '@/components/animate-ui/icons/icon';\n\ntype BetweenVerticalStartProps = IconProps<keyof typeof animations>;\n\nconst animations = {\n  default: {\n    leftRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: -2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    rightRect: {\n      initial: {\n        x: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        x: 2,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n    arrow: {\n      initial: {\n        y: 0,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n      animate: {\n        y: 3,\n        transition: { ease: 'easeInOut', duration: 0.3 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n  'default-loop': {\n    leftRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, -2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    rightRect: {\n      initial: { x: 0 },\n      animate: {\n        x: [0, 2, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n    arrow: {\n      initial: { y: 0 },\n      animate: {\n        y: [0, 3, 0],\n        transition: { ease: 'easeInOut', duration: 0.6 },\n      },\n    },\n  } satisfies Record<string, Variants>,\n} as const;\n\nfunction IconComponent({ size, ...props }: BetweenVerticalStartProps) {\n  const { controls } = useAnimateIconContext();\n  const variants = getVariants(animations);\n\n  return (\n    <motion.svg\n      xmlns=\"http://www.w3.org/2000/svg\"\n      width={size}\n      height={size}\n      viewBox=\"0 0 24 24\"\n      fill=\"none\"\n      stroke=\"currentColor\"\n      strokeWidth={2}\n      strokeLinecap=\"round\"\n      strokeLinejoin=\"round\"\n      {...props}\n    >\n      <motion.rect\n        width={7}\n        height={13}\n        x={3}\n        y={8}\n        rx={1}\n        variants={variants.leftRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.path\n        d=\"m15 2-3 3-3-3\"\n        variants={variants.arrow}\n        initial=\"initial\"\n        animate={controls}\n      />\n      <motion.rect\n        width={7}\n        height={13}\n        x={14}\n        y={8}\n        rx={1}\n        variants={variants.rightRect}\n        initial=\"initial\"\n        animate={controls}\n      />\n    </motion.svg>\n  );\n}\n\nfunction BetweenVerticalStart(props: BetweenVerticalStartProps) {\n  return <IconWrapper icon={IconComponent} {...props} />;\n}\n\nexport {\n  animations,\n  BetweenVerticalStart,\n  BetweenVerticalStart as BetweenVerticalStartIcon,\n  type BetweenVerticalStartProps,\n  type BetweenVerticalStartProps as BetweenVerticalStartIconProps,\n};\n",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-vertical-start.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "up",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "columns",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "vertical",
+      "start"
+    ]
+  }
+}

--- a/apps/www/public/r/registry.json
+++ b/apps/www/public/r/registry.json
@@ -6720,6 +6720,190 @@
       }
     },
     {
+      "name": "icons-between-horizontal-end",
+      "type": "registry:ui",
+      "title": "Between Horizontal End Icon",
+      "description": "Between horizontal end icon component.",
+      "registryDependencies": [
+        "@animate-ui/icons-icon"
+      ],
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/icons/between-horizontal-end/index.tsx",
+          "type": "registry:ui",
+          "target": "components/animate-ui/icons/between-horizontal-end.tsx"
+        }
+      ],
+      "meta": {
+        "keywords": [
+          "insert",
+          "add",
+          "left",
+          "slot",
+          "squeeze",
+          "space",
+          "grid",
+          "table",
+          "rows",
+          "cells",
+          "excel",
+          "spreadsheet",
+          "accountancy",
+          "data",
+          "enter",
+          "entry",
+          "entries",
+          "blocks",
+          "rectangles",
+          "chevron",
+          "between",
+          "horizontal",
+          "end"
+        ]
+      }
+    },
+    {
+      "name": "icons-between-horizontal-start",
+      "type": "registry:ui",
+      "title": "Between Horizontal Start Icon",
+      "description": "Between horizontal start icon component.",
+      "registryDependencies": [
+        "@animate-ui/icons-icon"
+      ],
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/icons/between-horizontal-start/index.tsx",
+          "type": "registry:ui",
+          "target": "components/animate-ui/icons/between-horizontal-start.tsx"
+        }
+      ],
+      "meta": {
+        "keywords": [
+          "insert",
+          "add",
+          "right",
+          "slot",
+          "squeeze",
+          "space",
+          "grid",
+          "table",
+          "rows",
+          "cells",
+          "excel",
+          "spreadsheet",
+          "accountancy",
+          "data",
+          "enter",
+          "entry",
+          "entries",
+          "blocks",
+          "rectangles",
+          "chevron",
+          "between",
+          "horizontal",
+          "start"
+        ]
+      }
+    },
+    {
+      "name": "icons-between-vertical-end",
+      "type": "registry:ui",
+      "title": "Between Vertical End Icon",
+      "description": "Between vertical end icon component.",
+      "registryDependencies": [
+        "@animate-ui/icons-icon"
+      ],
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/icons/between-vertical-end/index.tsx",
+          "type": "registry:ui",
+          "target": "components/animate-ui/icons/between-vertical-end.tsx"
+        }
+      ],
+      "meta": {
+        "keywords": [
+          "insert",
+          "add",
+          "down",
+          "slot",
+          "squeeze",
+          "space",
+          "grid",
+          "table",
+          "columns",
+          "cells",
+          "excel",
+          "spreadsheet",
+          "accountancy",
+          "data",
+          "enter",
+          "entry",
+          "entries",
+          "blocks",
+          "rectangles",
+          "chevron",
+          "between",
+          "vertical",
+          "end"
+        ]
+      }
+    },
+    {
+      "name": "icons-between-vertical-start",
+      "type": "registry:ui",
+      "title": "Between Vertical Start Icon",
+      "description": "Between vertical start icon component.",
+      "registryDependencies": [
+        "@animate-ui/icons-icon"
+      ],
+      "dependencies": [
+        "motion"
+      ],
+      "files": [
+        {
+          "path": "registry/icons/between-vertical-start/index.tsx",
+          "type": "registry:ui",
+          "target": "components/animate-ui/icons/between-vertical-start.tsx"
+        }
+      ],
+      "meta": {
+        "keywords": [
+          "insert",
+          "add",
+          "up",
+          "slot",
+          "squeeze",
+          "space",
+          "grid",
+          "table",
+          "columns",
+          "cells",
+          "excel",
+          "spreadsheet",
+          "accountancy",
+          "data",
+          "enter",
+          "entry",
+          "entries",
+          "blocks",
+          "rectangles",
+          "chevron",
+          "between",
+          "vertical",
+          "start"
+        ]
+      }
+    },
+    {
       "name": "icons-binary",
       "type": "registry:ui",
       "title": "Binary Icon",

--- a/apps/www/registry/icons/between-horizontal-end/index.tsx
+++ b/apps/www/registry/icons/between-horizontal-end/index.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import * as React from 'react';
+import { motion, type Variants } from 'motion/react';
+
+import {
+  getVariants,
+  useAnimateIconContext,
+  IconWrapper,
+  type IconProps,
+} from '@/registry/icons/icon';
+
+type BetweenHorizontalEndProps = IconProps<keyof typeof animations>;
+
+const animations = {
+  default: {
+    topRect: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: -2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    bottomRect: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: 2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    arrow: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: -3,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+  'default-loop': {
+    topRect: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, -2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    bottomRect: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, 2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    arrow: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, -3, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: BetweenHorizontalEndProps) {
+  const { controls } = useAnimateIconContext();
+  const variants = getVariants(animations);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <motion.rect
+        width={13}
+        height={7}
+        x={3}
+        y={3}
+        rx={1}
+        variants={variants.topRect}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.path
+        d="m22 15-3-3 3-3"
+        variants={variants.arrow}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.rect
+        width={13}
+        height={7}
+        x={3}
+        y={14}
+        rx={1}
+        variants={variants.bottomRect}
+        initial="initial"
+        animate={controls}
+      />
+    </motion.svg>
+  );
+}
+
+function BetweenHorizontalEnd(props: BetweenHorizontalEndProps) {
+  return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+  animations,
+  BetweenHorizontalEnd,
+  BetweenHorizontalEnd as BetweenHorizontalEndIcon,
+  type BetweenHorizontalEndProps,
+  type BetweenHorizontalEndProps as BetweenHorizontalEndIconProps,
+};

--- a/apps/www/registry/icons/between-horizontal-end/registry-item.json
+++ b/apps/www/registry/icons/between-horizontal-end/registry-item.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-horizontal-end",
+  "type": "registry:ui",
+  "title": "Between Horizontal End Icon",
+  "description": "Between horizontal end icon component.",
+  "registryDependencies": ["@animate-ui/icons-icon"],
+  "dependencies": ["motion"],
+  "files": [
+    {
+      "path": "registry/icons/between-horizontal-end/index.tsx",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-horizontal-end.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "left",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "rows",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "horizontal",
+      "end"
+    ]
+  }
+}
+
+

--- a/apps/www/registry/icons/between-horizontal-start/index.tsx
+++ b/apps/www/registry/icons/between-horizontal-start/index.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import * as React from 'react';
+import { motion, type Variants } from 'motion/react';
+
+import {
+  getVariants,
+  useAnimateIconContext,
+  IconWrapper,
+  type IconProps,
+} from '@/registry/icons/icon';
+
+type BetweenHorizontalStartProps = IconProps<keyof typeof animations>;
+
+const animations = {
+  default: {
+    topRect: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: -2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    bottomRect: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: 2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    arrow: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: 3,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+  'default-loop': {
+    topRect: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, -2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    bottomRect: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, 2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    arrow: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, 3, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: BetweenHorizontalStartProps) {
+  const { controls } = useAnimateIconContext();
+  const variants = getVariants(animations);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <motion.rect
+        width={13}
+        height={7}
+        x={8}
+        y={3}
+        rx={1}
+        variants={variants.topRect}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.path
+        d="m2 9 3 3-3 3"
+        variants={variants.arrow}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.rect
+        width={13}
+        height={7}
+        x={8}
+        y={14}
+        rx={1}
+        variants={variants.bottomRect}
+        initial="initial"
+        animate={controls}
+      />
+    </motion.svg>
+  );
+}
+
+function BetweenHorizontalStart(props: BetweenHorizontalStartProps) {
+  return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+  animations,
+  BetweenHorizontalStart,
+  BetweenHorizontalStart as BetweenHorizontalStartIcon,
+  type BetweenHorizontalStartProps,
+  type BetweenHorizontalStartProps as BetweenHorizontalStartIconProps,
+};

--- a/apps/www/registry/icons/between-horizontal-start/registry-item.json
+++ b/apps/www/registry/icons/between-horizontal-start/registry-item.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-horizontal-start",
+  "type": "registry:ui",
+  "title": "Between Horizontal Start Icon",
+  "description": "Between horizontal start icon component.",
+  "registryDependencies": ["@animate-ui/icons-icon"],
+  "dependencies": ["motion"],
+  "files": [
+    {
+      "path": "registry/icons/between-horizontal-start/index.tsx",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-horizontal-start.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "right",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "rows",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "horizontal",
+      "start"
+    ]
+  }
+}
+
+

--- a/apps/www/registry/icons/between-vertical-end/index.tsx
+++ b/apps/www/registry/icons/between-vertical-end/index.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import * as React from 'react';
+import { motion, type Variants } from 'motion/react';
+
+import {
+  getVariants,
+  useAnimateIconContext,
+  IconWrapper,
+  type IconProps,
+} from '@/registry/icons/icon';
+
+type BetweenVerticalEndProps = IconProps<keyof typeof animations>;
+
+const animations = {
+  default: {
+    leftRect: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: -2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    rightRect: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: 2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    arrow: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: -3,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+  'default-loop': {
+    leftRect: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, -2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    rightRect: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, 2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    arrow: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, -3, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: BetweenVerticalEndProps) {
+  const { controls } = useAnimateIconContext();
+  const variants = getVariants(animations);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <motion.rect
+        width={7}
+        height={13}
+        x={3}
+        y={3}
+        rx={1}
+        variants={variants.leftRect}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.path
+        d="m9 22 3-3 3 3"
+        variants={variants.arrow}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.rect
+        width={7}
+        height={13}
+        x={14}
+        y={3}
+        rx={1}
+        variants={variants.rightRect}
+        initial="initial"
+        animate={controls}
+      />
+    </motion.svg>
+  );
+}
+
+function BetweenVerticalEnd(props: BetweenVerticalEndProps) {
+  return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+  animations,
+  BetweenVerticalEnd,
+  BetweenVerticalEnd as BetweenVerticalEndIcon,
+  type BetweenVerticalEndProps,
+  type BetweenVerticalEndProps as BetweenVerticalEndIconProps,
+};

--- a/apps/www/registry/icons/between-vertical-end/registry-item.json
+++ b/apps/www/registry/icons/between-vertical-end/registry-item.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-vertical-end",
+  "type": "registry:ui",
+  "title": "Between Vertical End Icon",
+  "description": "Between vertical end icon component.",
+  "registryDependencies": ["@animate-ui/icons-icon"],
+  "dependencies": ["motion"],
+  "files": [
+    {
+      "path": "registry/icons/between-vertical-end/index.tsx",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-vertical-end.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "down",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "columns",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "vertical",
+      "end"
+    ]
+  }
+}

--- a/apps/www/registry/icons/between-vertical-start/index.tsx
+++ b/apps/www/registry/icons/between-vertical-start/index.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import * as React from 'react';
+import { motion, type Variants } from 'motion/react';
+
+import {
+  getVariants,
+  useAnimateIconContext,
+  IconWrapper,
+  type IconProps,
+} from '@/registry/icons/icon';
+
+type BetweenVerticalStartProps = IconProps<keyof typeof animations>;
+
+const animations = {
+  default: {
+    leftRect: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: -2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    rightRect: {
+      initial: {
+        x: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        x: 2,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+    arrow: {
+      initial: {
+        y: 0,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+      animate: {
+        y: 3,
+        transition: { ease: 'easeInOut', duration: 0.3 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+  'default-loop': {
+    leftRect: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, -2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    rightRect: {
+      initial: { x: 0 },
+      animate: {
+        x: [0, 2, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+    arrow: {
+      initial: { y: 0 },
+      animate: {
+        y: [0, 3, 0],
+        transition: { ease: 'easeInOut', duration: 0.6 },
+      },
+    },
+  } satisfies Record<string, Variants>,
+} as const;
+
+function IconComponent({ size, ...props }: BetweenVerticalStartProps) {
+  const { controls } = useAnimateIconContext();
+  const variants = getVariants(animations);
+
+  return (
+    <motion.svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <motion.rect
+        width={7}
+        height={13}
+        x={3}
+        y={8}
+        rx={1}
+        variants={variants.leftRect}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.path
+        d="m15 2-3 3-3-3"
+        variants={variants.arrow}
+        initial="initial"
+        animate={controls}
+      />
+      <motion.rect
+        width={7}
+        height={13}
+        x={14}
+        y={8}
+        rx={1}
+        variants={variants.rightRect}
+        initial="initial"
+        animate={controls}
+      />
+    </motion.svg>
+  );
+}
+
+function BetweenVerticalStart(props: BetweenVerticalStartProps) {
+  return <IconWrapper icon={IconComponent} {...props} />;
+}
+
+export {
+  animations,
+  BetweenVerticalStart,
+  BetweenVerticalStart as BetweenVerticalStartIcon,
+  type BetweenVerticalStartProps,
+  type BetweenVerticalStartProps as BetweenVerticalStartIconProps,
+};

--- a/apps/www/registry/icons/between-vertical-start/registry-item.json
+++ b/apps/www/registry/icons/between-vertical-start/registry-item.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://ui.shadcn.com/schema/registry-item.json",
+  "name": "icons-between-vertical-start",
+  "type": "registry:ui",
+  "title": "Between Vertical Start Icon",
+  "description": "Between vertical start icon component.",
+  "registryDependencies": ["@animate-ui/icons-icon"],
+  "dependencies": ["motion"],
+  "files": [
+    {
+      "path": "registry/icons/between-vertical-start/index.tsx",
+      "type": "registry:ui",
+      "target": "components/animate-ui/icons/between-vertical-start.tsx"
+    }
+  ],
+  "meta": {
+    "keywords": [
+      "insert",
+      "add",
+      "up",
+      "slot",
+      "squeeze",
+      "space",
+      "grid",
+      "table",
+      "columns",
+      "cells",
+      "excel",
+      "spreadsheet",
+      "accountancy",
+      "data",
+      "enter",
+      "entry",
+      "entries",
+      "blocks",
+      "rectangles",
+      "chevron",
+      "between",
+      "vertical",
+      "start"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animate-ui",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "private": true,
   "scripts": {
     "build": "turbo build",


### PR DESCRIPTION
# Add Between Horizontal/Vertical Icons

Adds four Lucide icons with Animate UI variants:

- [between-horizontal-start](https://lucide.dev/icons/between-horizontal-start)
- [between-horizontal-end](https://lucide.dev/icons/between-horizontal-end)
- [between-vertical-start](https://lucide.dev/icons/between-vertical-start)
- [between-vertical-end](https://lucide.dev/icons/between-vertical-end)


https://github.com/user-attachments/assets/6f509ed4-7c6f-4108-82bf-f10654ba5a06

## Description

Animated "between" icons that indicate inserting content between blocks. Each icon supports subtle motion on the surrounding blocks with a directional chevron that nudges toward the blocks.

## Animation Variants

Horizontal icons: rounded rects translate on y by ±2px; chevron translates on x by 3px toward the blocks (start → +3px, end → -3px).

Vertical icons: rounded rects translate on x by ±2px; chevron translates on y by 3px toward the blocks (start → +3px, end → -3px).

All four icons include two variants:

- **`default`** — One-shot motion where the blocks translate "out" by ±2px; chevron translates towards the bloks by 3px
- **`default-loop`** — Looping version of the default motion

## Keywords

Matches Lucide's categories and tags 

> insert • add • top/left/right/bottom • slot • squeeze • space • vertical/horizontal • grid • table • columns • cells • data • enter • entry • entries • blocks • rectangles • chevron