### PR TITLE
fix: wrapper component not passing props to base component

### DIFF
--- a/apps/www/registry/components/radix/sheet/index.tsx
+++ b/apps/www/registry/components/radix/sheet/index.tsx
@@ -76,6 +76,7 @@ function SheetContent({
           side === 'bottom' && 'w-full h-[350px] border-t',
           className,
         )}
+        side={side}
         {...props}
       >
         {children}


### PR DESCRIPTION
## Summary

This PR fixes an issue where the wrapper component of sheet failed to pass through `side` prop to the underlying base component.

Inside the wrapper component, `side` was destructured separately:

## Problem

```ts
function SheetContent({
  className,
  children,
  side = 'right',
  showCloseButton = true,
  ...props
```

Because of the destructuring, `side` was no longer included in `...props`, so it was never forwarded to the base component.