### PR TITLE
fix(hero): prevent layout shift by hiding vertical overflow

### DIFF
--- a/apps/www/components/hero.tsx
+++ b/apps/www/components/hero.tsx
@@ -17,7 +17,7 @@ const TITLE = 'Animate your UI with smooth style';
 
 export const Hero = () => {
   return (
-    <div className="relative overflow-x-hidden flex flex-col items-center px-5">
+    <div className="relative overflow-hidden flex flex-col items-center px-5">
       <div className="relative z-10 flex flex-col items-center justify-center pt-30">
         <MotionEffect
           slide={{


### PR DESCRIPTION
Fixes #156 

### Summary
This PR fixes a UI issue where the homepage briefly shows double scrollbars and a layout shift when the Hero section animations mount.

### Cause
The Hero container used `overflow-x-hidden`, which hides only horizontal overflow. 
Animations that slide from the bottom create temporary vertical overflow.

### Fix
Replaced:
- `overflow-x-hidden`
with:
- `overflow-hidden`

### Result
- No scrollbar flash  
- No layout shift  
- Smoother animation load  
