### PR TITLE
fix: add missing getStrictContext helper required for ThemeToggler & Particles components

### DIFF
--- a/apps/www/lib/get-strict-context.ts
+++ b/apps/www/lib/get-strict-context.ts
@@ -1,0 +1,15 @@
+import { createContext, useContext } from "react";
+
+export function getStrictContext<T>(name: string) {
+  const Context = createContext<T | undefined>(undefined);
+
+  const useStrictContext = () => {
+    const ctx = useContext(Context);
+    if (!ctx) {
+      throw new Error(`${name} is missing a Context Provider`);
+    }
+    return ctx;
+  };
+
+  return [Context.Provider, useStrictContext] as const;
+}


### PR DESCRIPTION
## Summary
Using the command below from the documentation:

npx shadcn@latest add @animate-ui/components-buttons-theme-toggler


generates components (`theme-toggler.tsx`, `icon.tsx`, `particles.tsx`) that import:

import { getStrictContext } from "@/lib/get-strict-context"



However, the file `get-strict-context.ts` is not included in the generator templates, causing both  
`npm run dev` and `npm run build` to fail with:

❌ Module not found: Can't resolve '@/lib/get-strict-context'

This PR adds the missing file and ensures the generated components work out of the box.

---

## What This PR Fixes

- Adds the missing strict context helper `getStrictContext`.
- Prevents build-time and runtime failures in:
  - `particles.tsx`
  - `icon.tsx`
  - `theme-toggler.tsx`
- Ensures `ThemeTogglerButton` works without requiring users to manually add missing files.

---

## Implementation Details

Added a new file in the library:

### `lib/get-strict-context.ts`

```ts
import { createContext, useContext } from "react";

export function getStrictContext<T>(name: string) {
  const Context = createContext<T | undefined>(undefined);

  const useStrictContext = () => {
    const ctx = useContext(Context);
    if (!ctx) {
      throw new Error(`${name} is missing a Context Provider`);
    }
    return ctx;
  };

  return [Context.Provider, useStrictContext] as const;
}

```
This matches the expected import path used by the generated Animate UI components.

---

## Reproduction Steps

### 1. Create a fresh Next.js project:
```bash
 npx create-next-app my-app --yes
 ```     
### 2. Initialize shadcn:
```bash
 npx shadcn@latest init
```
### 3. Add the Theme Toggler:
```bash
npx shadcn@latest add @animate-ui/components-buttons-theme-toggler
```
### 4. Use This  in any page.
```bash
<ThemeTogglerButton />
```

### 5. Run the app:
```bash
npm run dev
```

### 6. Observe the error:
- Module not found: '@/lib/get-strict-context'

### After applying this PR and re-running the generator:
- ✔ No missing module errors  
- ✔ Theme toggler + particle animations work as expected  
- ✔ No manual fixes needed

### Additional Notes
- This PR resolves issue #162.
- No breaking changes.
- No changes required from existing users.
- Makes the shadcn generator output fully functional components.