### PR TITLE
fix: update delay type in TooltipProps definition

### DIFF
--- a/apps/www/registry/components/base/tooltip/index.tsx
+++ b/apps/www/registry/components/base/tooltip/index.tsx
@@ -23,7 +23,7 @@ function TooltipProvider({ delay = 0, ...props }: TooltipProviderProps) {
 }
 
 type TooltipProps = TooltipPrimitiveProps & {
-  delay?: TooltipPrimitiveProps['delay'];
+  delay?: TooltipProviderPrimitiveProps['delay'];
 };
 
 function Tooltip({ delay = 0, ...props }: TooltipProps) {


### PR DESCRIPTION
the `delay` prop is available from the provider not the root in base ui